### PR TITLE
fix: Only minimise intra-distance for focus group when focus is set

### DIFF
--- a/tests/dummy_test.py
+++ b/tests/dummy_test.py
@@ -1,0 +1,6 @@
+"""Just a dummy test, as Pytest requires at least one test to run."""
+
+
+def test_dummy() -> None:
+    """A dummy test that always passes."""
+    assert True


### PR DESCRIPTION
Previously, in the optimisation process, we minimised for the intra-cluster distance between all the groups implicitly, as we were minimising `intra_focus + intra_k` for all `k`. Now we are _only_ minimising intra-cluster distance within the focus group (if set), along with maximising the distance from the focus centroid to all the other centroids.